### PR TITLE
Use Preact in production build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,16 @@ module.exports = {
   env: {
     PUBLIC_PATH: publicPath.trim().replace(/\/$/, ""),
   },
+  webpack: (config, { dev, isServer }) => {
+    // Replace React with Preact only in client production build
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: "preact/compat",
+        "react-dom/test-utils": "preact/test-utils",
+        "react-dom": "preact/compat",
+      });
+    }
+
+    return config;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gray-matter": "^4.0.2",
     "joi": "^17.3.0",
     "next": "^10.0.5",
+    "preact": "^10.5.12",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "reading-time": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,6 +3835,11 @@ postcss@^8.1.6, postcss@^8.2.1, postcss@^8.2.4:
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
+preact@^10.5.12:
+  version "10.5.12"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.12.tgz#6a8ee8bf40a695c505df9abebacd924e4dd37704"
+  integrity sha512-r6siDkuD36oszwlCkcqDJCAKBQxGoeEGytw2DGMD5A/GGdu5Tymw+N2OBXwvOLxg6d1FeY8MgMV3cc5aVQo4Cg==
+
 prebuild-install@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.0.0.tgz#669022bcde57c710a869e39c5ca6bf9cd207f316"


### PR DESCRIPTION
This is generally 40% less JS to load for the same feature at the end.

Example for a blog post page: in react we have 75,2.kb of JS, and with Preact we have 41.5 kb of JS.

### Build with React:
![image](https://user-images.githubusercontent.com/95120/106112608-c1661180-614d-11eb-8d39-96c09906c19d.png)

### Build with Preact:
![image](https://user-images.githubusercontent.com/95120/106112634-cd51d380-614d-11eb-9c82-ca637cd3e47b.png)
