### PR TITLE
Prevent tailwindcss to purge all styles

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ["./components/**/*.tsx", "./pages/**/*.tsx"],
+  purge: ["./src/components/**/*.tsx", "./src/pages/**/*.tsx"],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
As we move all source code from the root to the `src/` directory, the config should be adapted