### PR TITLE
fix: add responsive authors layout and use Next Image for author avatar

### DIFF
--- a/src/components/author.tsx
+++ b/src/components/author.tsx
@@ -1,4 +1,5 @@
 import { Author as AuthorType, AuthorNode } from "../../src/types";
+import Image from "next/image";
 
 export const Author = ({
   name,
@@ -6,7 +7,15 @@ export const Author = ({
 }: Pick<AuthorType, "name" | "picture">) => {
   return (
     <div className="flex items-center">
-      <img src={picture} className="w-12 h-12 rounded-full mr-4" alt={name} />
+      <div className="mr-4">
+        <Image
+          src={picture}
+          className="rounded-full"
+          alt={name}
+          width={48}
+          height={48}
+        />
+      </div>
       <div className="text-xl font-bold text-secondary">{name}</div>
     </div>
   );
@@ -20,7 +29,7 @@ const Authors = ({ authors }: { authors: AuthorNode[] }) => {
   }
 
   return (
-    <div className="flex items-center space-x-8">
+    <div className="flex flex-col space-y-4 sm:flex-row sm:space-x-8 sm:space-y-0">
       {authors.map((oneAuthorNode) => {
         if (!oneAuthorNode || !oneAuthorNode.frontMatter) {
           throw new Error("Invalid AuthorNode: missing frontMatter entry");


### PR DESCRIPTION
fix #58 the authors will now display in column on little screen size :

![Capture d’écran de 2021-04-28 17-21-20](https://user-images.githubusercontent.com/10562213/116429473-34168400-a846-11eb-92e1-81d49216f3f7.png)
