### PR TITLE
fix: add more space between the footer button on mobile

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -10,7 +10,7 @@ const Footer = () => {
             Follow our journey while we build the best customer & operations
             experiences of hospitality world.
           </h3>
-          <div className="flex flex-col lg:flex-row justify-end items-center lg:pl-4 lg:w-1/2">
+          <div className="flex flex-col lg:flex-row justify-end items-center lg:pl-4 lg:w-1/2 space-y-4 lg:space-y-0">
             <a
               href={rssFeedRoute()}
               className="mx-3 text-secondary-inverted font-bold hover:underline"


### PR DESCRIPTION
fix #61 add "space-y-4" class make a 1rem space between the buttons :
![Capture d’écran de 2021-04-29 10-19-47](https://user-images.githubusercontent.com/10562213/116521626-7be3ec80-a8d4-11eb-89d9-60ecdcb60802.png)
